### PR TITLE
fix numeric need be float  

### DIFF
--- a/deriv_api/deriv_api_calls.py
+++ b/deriv_api/deriv_api_calls.py
@@ -7006,7 +7006,9 @@ def parse_args(all_args):
         ptype = config[param].get('type')
         if ptype and ptype == 'string':
             parsed_args[param] = f'{value}'
-        elif ptype and (ptype == 'numeric' or ptype == 'boolean'):
+        elif ptype and ptype == 'numeric':
+            parsed_args[param] = float(value)
+        elif ptype and ptype == 'boolean':
             parsed_args[param] = int(float(value))
             
     return parsed_args


### PR DESCRIPTION
in this sample deriv can input float amount like `2.5` but the code `numeric` is change to int() `2`, so change numeric to float can fix
```python
proposal = await api.proposal({"proposal": 1, "amount": 100, "barrier": "+0.1", "basis": "payout",
                                   "contract_type": "CALL", "currency": "USD", "duration": 60, "duration_unit": "s",
                                   "symbol": "R_100"})
print(proposal) 
```